### PR TITLE
Use canonical category IDs for category handling

### DIFF
--- a/src/helpers/renderCategories.js
+++ b/src/helpers/renderCategories.js
@@ -47,10 +47,17 @@ export function renderCategoriesList(categoriesRoot, page = 0, perPage = 40) {
   const root = extractRoot(categoriesRoot);
 
   const items = (Array.isArray(root) ? root : [])
-    .map(x => ({
-      id: x?.id ?? x?.categoryId ?? x?.code ?? '',
-      name: String(x?.name ?? x?.title ?? 'Без названия'),
-    }))
+    .map((x) => {
+      const canonicalId = x?.categoryId ?? x?.CategoryId ?? x?.categoryID ?? null;
+      const fallbackId = x?.id ?? x?.code ?? null;
+      const resolvedId = canonicalId ?? fallbackId ?? '';
+
+      return {
+        id: resolvedId,
+        canonicalId,
+        name: String(x?.name ?? x?.title ?? 'Без названия'),
+      };
+    })
     .filter(x => String(x.id).length > 0);
 
   if (!items.length) {
@@ -75,7 +82,7 @@ export function renderCategoriesList(categoriesRoot, page = 0, perPage = 40) {
     rows.push(
       slice.slice(i, i + 2).map(it => ({
         text: truncate(it.name, 48),
-        callback_data: `cat:${it.id}`,
+        callback_data: `cat:${it.canonicalId ?? it.id}`,
       }))
     );
   }

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -8,7 +8,7 @@ import {
 } from './helpers/renderCategories.js';
 import {
   saveCategoriesSession,
-  getCategorySsd,
+  getCategoryRecord,
   setUserVehicle,
   getUserVehicle,
   setCategoriesRoot,
@@ -344,7 +344,10 @@ await this._safeSendMessage(chatId, '.', {
       if (!ctx?.catalog) throw new Error('Контекст автомобиля не найден. Повтори VIN.');
       const { catalog, vehicleId } = ctx;
 
-      const ssd = await getCategorySsd(userId, catalog, vehicleId || '0', categoryId);
+      const category = await getCategoryRecord(userId, catalog, vehicleId || '0', categoryId);
+      const ssd = category?.ssd;
+      const canonicalCategoryId = category?.categoryId ?? categoryId;
+
       if (!ssd) throw new Error('Сессия категорий устарела. Повтори VIN.');
 
       const base = (process.env.LAXIMO_BASE_URL || '').replace(/\/+$/, '');
@@ -352,7 +355,7 @@ await this._safeSendMessage(chatId, '.', {
       uUrl.searchParams.set('catalog', catalog);
       uUrl.searchParams.set('vehicleId', vehicleId || '0');
       uUrl.searchParams.set('ssd', ssd);
-      uUrl.searchParams.set('categoryId', String(categoryId));
+      uUrl.searchParams.set('categoryId', String(canonicalCategoryId));
 
       const uRes = await fetch(uUrl.toString());
       const uJson = await uRes.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- expose cached category records so callers can access canonical IDs along with SSD values
- prefer API-provided canonical categoryId when building category callback data
- ensure the category handler reads the full cached record and sends the canonical ID to the /units request

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68dfd50632a0832a92a1d87c28cb6e15